### PR TITLE
fix path of axe.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-a11y-checker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Accessibility test module for components",
   "main": "index.js",
   "bin": {

--- a/src/axe-driver.js
+++ b/src/axe-driver.js
@@ -8,7 +8,7 @@ import Driver from './helpers/Driver';
 
 const SERVER_PORT = 8899;
 const SERVER_PATH = './';
-const PATH_TO_AXE = '../node_modules/axe-core/axe.min.js';
+const PATH_TO_AXE = './node_modules/axe-core/axe.min.js';
 const appDirectory = fs.realpathSync(process.cwd());
 const log = console.log;
 
@@ -29,7 +29,7 @@ function resolvePath(relativePath) {
  * @return {Promise}
  */
 async function executeAxe(page) {
-  await page.injectFile(path.resolve(__dirname, PATH_TO_AXE));
+  await page.injectFile(resolvePath(PATH_TO_AXE));
   return await page.evaluate(() => {
     return axe.run();
   });


### PR DESCRIPTION
### Issue
Puppeteer uses invalid path to fetch `axe.min.js` when `metal-a11y-checker` runs from a root folder.

### Resolve
`axe-core` is always located relative to the root project as `npm` hoist dependencies into the root projects `node_modules` folder..