### PR TITLE
Fixing devDependencies name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The tool exposes an executable that can be used to set up the testing environmen
 ```
 "devDependency": {
   ...
-  "metal-a11y": "^1.0.0",
+  "metal-a11y-checker": "^1.0.5",
   ...
 }
 ```


### PR DESCRIPTION
When I tried to get the `metal-a11y` package an error occurred during the installation, I realized that the package was named wrong in README.md.