### PR TITLE
Add --no-sandbox argument to Puppeteer when metal-a11y is called with --ci-mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-a11y-checker",
-  "version": "1.0.3",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enjikaka/metal-a11y-checker",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Accessibility test module for components",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "metal-a11y-checker",
+  "name": "@enjikaka/metal-a11y-checker",
   "version": "1.0.5",
   "description": "Accessibility test module for components",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "karlsson-metal-a11y-checker",
-  "version": "1.0.6",
+  "name": "metal-a11y-checker",
+  "version": "1.0.5",
   "description": "Accessibility test module for components",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@enjikaka/metal-a11y-checker",
+  "name": "karlsson-metal-a11y-checker",
   "version": "1.0.6",
   "description": "Accessibility test module for components",
   "main": "index.js",

--- a/src/axe-driver.js
+++ b/src/axe-driver.js
@@ -91,7 +91,7 @@ function sadPath(axeReport) {
  * Returns the first available port starting from the given number
  * @async
  * @param {number} port
- * @return {number} available port
+ * @return {Promise.<number>} available port
  */
 async function getAvailablePort(port) {
   const availablePort = await detect(port);
@@ -100,15 +100,23 @@ async function getAvailablePort(port) {
 }
 
 /**
+ * @typedef ExecOptions
+ * @prop {string} indexHtml - used to specifiy the demo page of the component
+ * @prop {string} serverPath - document root
+ * @prop {boolean} [verbose]
+ * @prop {boolean} ciMode
+ */
+
+/**
  * Executes the test against the given url that is hosted at the
  * specified document root.
  * @async
- * @param {string} indexHtml - used to specifiy the demo page of the component
- * @param {string} serverPath - document root
- * @param {boolean} verbose
+ * @param {ExecOptions} options
  * @return {Promise}
  */
-async function exec({indexHtml, serverPath, verbose}) {
+async function exec(options) {
+  const {indexHtml, serverPath, verbose, ciMode} = options;
+
   if (!verbose) console.log = () => {};
 
   const port = await getAvailablePort(SERVER_PORT);
@@ -120,7 +128,7 @@ async function exec({indexHtml, serverPath, verbose}) {
   driver.on('exit', server.stop);
 
   const url = `http://localhost:${serverConfig.port}/${indexHtml}`;
-  const page = await driver.connect(url);
+  const page = await driver.connect(url, {ciMode});
   const report = await executeAxe(page);
 
   await driver.exit();

--- a/src/axe-runner.js
+++ b/src/axe-runner.js
@@ -102,6 +102,8 @@ function traverseObj(obj, callback) {
   Object.keys(obj).forEach(key => callback(obj[key], key));
 }
 
+const ciMode = Boolean(argv['ci-mode']);
+
 if (argv['packages']) {
   const packagesDir = argv['packages'] || 'packages';
   const packagesPath = path.join(path.resolve(appDirectory), packagesDir);
@@ -110,9 +112,10 @@ if (argv['packages']) {
   dl.list(`${packagesPath}/`, true, list => {
     const loop = list.reduce((promise, dir) => {
       return promise
-        .then(() =>
-          exec({indexHtml, serverPath: path.join(packagesPath, dir)})
-        )
+        .then(() => {
+          const serverPath = path.join(packagesPath, dir);
+          exec({indexHtml, serverPath, ciMode});
+        })
         .then(report => (reports[dir] = report));
     }, Promise.resolve());
 
@@ -122,7 +125,7 @@ if (argv['packages']) {
       .catch(ex => processException(ex));
   });
 } else {
-  exec({indexHtml, serverPath})
+  exec({indexHtml, serverPath, ciMode})
     .then(report => (decorate(report), processReport(report)))
     .catch(ex => processException(ex));
 }

--- a/src/helpers/Driver.js
+++ b/src/helpers/Driver.js
@@ -15,15 +15,29 @@ class Driver {
   }
 
   /**
+   * @typedef ConnectOptions
+   * @prop {boolean} ciMode
+   */
+
+  /**
    * Creates a Puppeteer instance and connects to the given address
    * @param {string} address
+   * @param {ConnectOptions} options
    * @return {Promise}
    */
-  async connect(address) {
-    this.browser = await puppeteer.launch();
+  async connect(address, options) {
+    const {ciMode} = options;
+    const launchOptions = ciMode
+      ? {
+          args: ['--no-sandbox'],
+        }
+      : {};
+    this.browser = await puppeteer.launch(launchOptions);
     const page = await this.browser.newPage();
     await page.goto(address, {waitUntil: 'load'});
-    console.log(`Connected to ${address}`);
+    console.log(
+      `Connected to ${address}${ciMode ? ', using --no-sandbox' : ''}`
+    );
     this.emitter.emit('connect');
     return page;
   }

--- a/src/helpers/Server.js
+++ b/src/helpers/Server.js
@@ -1,17 +1,17 @@
 import {Promise} from 'es6-promise';
 import express from 'express';
 
-/** 
+/**
  * Wrapper around setting up an express server with static middleware
  */
 class Server {
   /**
-	 * Starts the express server
-	 * @param {number} port
-	 * @param {string} dir
-	 * @return {Promise}
-	 * @throw {Error}
-	 */
+   * Starts the express server
+   * @param {number} port
+   * @param {string} dir
+   * @return {Promise}
+   * @throw {Error}
+   */
   start(port, dir) {
     if (this.app) throw new Error('Server is already running!');
 
@@ -30,9 +30,9 @@ class Server {
   }
 
   /**
-	 * Stops the server
-	 * @return {Promise}
-	 */
+   * Stops the server
+   * @return {Promise}
+   */
   stop() {
     return Promise.resolve().then(() => this.server.close());
   }


### PR DESCRIPTION
Fix for #16. Published this on npm under `karlsson-metal-a11y-checker` to test.

Changes:
- Add --no-sandbox argument to Puppeteer when metal-a11y is called with --ci-mode
- Correct some JSDocs

To test with docker;

Dockerfile:

```
FROM node:8-slim

# See https://crbug.com/795759
RUN apt-get update && apt-get install -yq libgconf-2-4

# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
# installs, work.
RUN apt-get update && apt-get install -y wget --no-install-recommends \
    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
    && apt-get update \
    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
      --no-install-recommends \
    && rm -rf /var/lib/apt/lists/* \
    && apt-get purge --auto-remove -y curl \
    && rm -rf /src/*.deb

# It's a good idea to use dumb-init to help prevent zombie chrome processes.
ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
RUN chmod +x /usr/local/bin/dumb-init

# Uncomment to skip the chromium download when installing puppeteer. If you do,
# you'll need to launch puppeteer with:
#     browser.launch({executablePath: 'google-chrome-unstable'})
# ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true

RUN mkdir -p /home/pptruser/app
WORKDIR /home/pptruser/app

# Install puppeteer so it's available in the container.
RUN yarn add puppeteer

# Add user so we don't need --no-sandbox.
RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
    && mkdir -p /home/pptruser/Downloads \
    && chown -R pptruser:pptruser /home/pptruser

# Run everything after as non-privileged user.
USER pptruser

RUN yarn add karlsson-metal-a11y-checker
RUN echo '{ "scripts": { "start": "metal-a11y --ci-mode --root ./test --content index.html" } }' > package.json
ENTRYPOINT [ "npm", "start" ]
```

docker-compose.yml:
```
version: '3'

services:
  axe:
    build:
      context: .
      dockerfile: Dockerfile
    working_dir: /home/pptruser/app
    volumes:
      - "./build:/home/pptruser/app/test"
```

Run `docker-compose up axe` to run metal-a11y on build folder on host.